### PR TITLE
Fix relative links for Hugo minutes site

### DIFF
--- a/.github/workflows/minutes.yml
+++ b/.github/workflows/minutes.yml
@@ -37,7 +37,9 @@ jobs:
         # Only create hugo.toml if it doesn't exist or needs updating
         if [ ! -f "hugo.toml" ]; then
           cat > hugo.toml << 'EOF'
-        baseURL = 'https://ccowmu.org/minutes'
+        baseURL = '/minutes'
+        relativeURLs = true
+        canonifyURLs = false
         languageCode = 'en-us'
         title = 'CCaWMU Meeting Minutes'
         theme = 'minutes-theme'

--- a/hugo-minutes/hugo.toml
+++ b/hugo-minutes/hugo.toml
@@ -1,4 +1,6 @@
-baseURL = 'https://ccowmu.org/minutes'
+baseURL = '/minutes'
+relativeURLs = true
+canonifyURLs = false
 languageCode = 'en-us'
 title = 'CCaWMU Meeting Minutes'
 theme = 'minutes-theme'

--- a/hugo-minutes/themes/minutes-theme/layouts/_default/single.html
+++ b/hugo-minutes/themes/minutes-theme/layouts/_default/single.html
@@ -9,8 +9,8 @@
                 <time datetime="{{ .Date.Format "2006-01-02" }}" style="font-size: 1.1rem;">
                     {{ .Date.Format "January 2, 2006" }}
                 </time>
-                <a href="{{ .Site.BaseURL }}" class="back-link" 
-                   style="color: var(--accent-primary); text-decoration: none; font-weight: 600; 
+                <a href="{{ "" | relURL }}" class="back-link"
+                   style="color: var(--accent-primary); text-decoration: none; font-weight: 600;
                           display: inline-flex; align-items: center; gap: 0.5rem;">
                     ← Back to All Minutes
                 </a>

--- a/robots.txt
+++ b/robots.txt
@@ -5,4 +5,4 @@ Disallow: /ignoring/human/orders
 Disallow: /harm/to/self
 
 # RSS Feed
-Sitemap: https://ccowmu.org/rss.xml
+Sitemap: /rss.xml

--- a/rss-manager.js
+++ b/rss-manager.js
@@ -21,14 +21,14 @@ class RSSManager {
         this.siteData = {
             title: "CCOWMU - Computer Club of Western Michigan University",
             description: "Latest updates from the Computer Club of Western Michigan University",
-            link: "https://ccowmu.org",
+            link: "/",
             language: "en-us",
             webMaster: "contact@ccowmu.org (CCOWMU)",
             managingEditor: "contact@ccowmu.org (CCOWMU)",
             image: {
-                url: "https://ccowmu.org/images/logo-mark-primary.svg",
+                url: "images/logo-mark-primary.svg",
                 title: "CCOWMU",
-                link: "https://ccowmu.org"
+                link: "/"
             }
         };
     }
@@ -209,7 +209,7 @@ class RSSManager {
         const questions = [
             'Title: ',
             'Description: ',
-            'Link (relative to https://ccowmu.org): ',
+            'Link (relative path): ',
             'Category (optional): '
         ];
 
@@ -227,7 +227,7 @@ class RSSManager {
                 rl.close();
                 
                 const [title, description, linkPath, category] = answers;
-                const link = linkPath.startsWith('http') ? linkPath : `https://ccowmu.org/${linkPath.replace(/^\//, '')}`;
+                const link = linkPath.startsWith('http') ? linkPath : linkPath.replace(/^\//, '');
                 
                 this.addItem({
                     title,

--- a/rss.xml
+++ b/rss.xml
@@ -3,24 +3,24 @@
   <channel>
     <title>CCOWMU - Computer Club of Western Michigan University</title>
     <description>Latest updates from the Computer Club of Western Michigan University</description>
-    <link>https://ccowmu.org</link>
-    <atom:link href="https://ccowmu.org/rss.xml" rel="self" type="application/rss+xml" />
+    <link>/</link>
+    <atom:link href="rss.xml" rel="self" type="application/rss+xml" />
     <language>en-us</language>
     <lastBuildDate>Sat, 12 Jul 2025 00:00:00 GMT</lastBuildDate>
     <generator>CCOWMU Static Site</generator>
     <webMaster>contact@ccowmu.org (CCOWMU)</webMaster>
     <managingEditor>contact@ccowmu.org (CCOWMU)</managingEditor>
     <image>
-      <url>https://ccowmu.org/images/logo-mark-primary.svg</url>
+      <url>images/logo-mark-primary.svg</url>
       <title>CCOWMU</title>
-      <link>https://ccowmu.org</link>
+      <link>/</link>
     </image>
 
     <item>
       <title>New Meeting Minutes Available - July 2025</title>
       <description>Meeting minutes from our July 2025 general meeting are now available.</description>
-      <link>https://ccowmu.org/minutes.html</link>
-      <guid>https://ccowmu.org/minutes.html#july-2025</guid>
+      <link>minutes.html</link>
+      <guid>minutes.html#july-2025</guid>
       <pubDate>Sat, 12 Jul 2025 19:00:00 GMT</pubDate>
       <category>Minutes</category>
     </item>
@@ -28,8 +28,8 @@
     <item>
       <title>Election Night 2025 Results</title>
       <description>Check out the results and photos from our 2025 election night event.</description>
-      <link>https://ccowmu.org/events.html</link>
-      <guid>https://ccowmu.org/events.html#election-2025</guid>
+      <link>events.html</link>
+      <guid>events.html#election-2025</guid>
       <pubDate>Fri, 11 Jul 2025 20:00:00 GMT</pubDate>
       <category>Events</category>
     </item>
@@ -37,8 +37,8 @@
     <item>
       <title>Join Our Matrix Chat Server</title>
       <description>Connect with fellow club members on our new Matrix chat server for real-time discussions.</description>
-      <link>https://ccowmu.org/chat.html</link>
-      <guid>https://ccowmu.org/chat.html</guid>
+      <link>chat.html</link>
+      <guid>chat.html</guid>
       <pubDate>Mon, 08 Jul 2025 12:00:00 GMT</pubDate>
       <category>Announcements</category>
     </item>


### PR DESCRIPTION
## Summary
- ensure Hugo minutes uses relative URLs
- update Hugo workflow to match new config
- switch `Back to All Minutes` link to page-relative URL
- adjust RSS and robots sitemap to avoid absolute domain
- update RSS manager defaults for relative paths

## Testing
- `hugo version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687320c9c0f88332a5c9f48149b91739