### PR TITLE
Automate Hugo minutes build

### DIFF
--- a/.github/workflows/minutes.yml
+++ b/.github/workflows/minutes.yml
@@ -1,0 +1,99 @@
+name: Build Minutes
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+
+      - name: Checkout minutes source
+        uses: actions/checkout@v4
+        with:
+          repository: ccowmu/minutes
+          path: minutes-src
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.120.4'
+          extended: true
+
+      - name: Prepare site
+        run: |
+          mkdir -p hugo-minutes/content
+          rsync -av --delete minutes-src/minutes/ hugo-minutes/content/
+          cat > hugo-minutes/hugo.toml <<'CONF'
+baseURL = "/minutes/"
+relativeURLs = true
+canonifyURLs = false
+languageCode = "en-us"
+title = "CCaWMU Meeting Minutes"
+theme = "minutes-theme"
+paginate = 20
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+CONF
+          mkdir -p hugo-minutes/themes/minutes-theme/layouts/_default
+          mkdir -p hugo-minutes/themes/minutes-theme/layouts/partials
+          cp includes/header.html hugo-minutes/themes/minutes-theme/layouts/partials/
+          cp includes/footer.html hugo-minutes/themes/minutes-theme/layouts/partials/
+          cat > hugo-minutes/themes/minutes-theme/layouts/_default/baseof.html <<'CONF'
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+  <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+</head>
+<body>
+  {{ partial "header.html" . }}
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+  {{ partial "footer.html" . }}
+  <script src="{{ "js/main.js" | relURL }}"></script>
+</body>
+</html>
+CONF
+          cat > hugo-minutes/themes/minutes-theme/layouts/_default/list.html <<'CONF'
+{{ define "title" }}Meeting Minutes - {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<h1>Meeting Minutes</h1>
+<ul>
+  {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> - {{ .Date.Format "Jan 2, 2006" }}</li>
+  {{ end }}
+</ul>
+{{ end }}
+CONF
+          cat > hugo-minutes/themes/minutes-theme/layouts/_default/single.html <<'CONF'
+{{ define "title" }}{{ .Title }} - {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<article>
+  <h1>{{ .Title }}</h1>
+  <time>{{ .Date.Format "January 2, 2006" }}</time>
+  {{ .Content }}
+</article>
+{{ end }}
+CONF
+
+      - name: Build site
+        run: |
+          hugo -s hugo-minutes -d ../minutes --minify
+
+      - name: Commit minutes
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add minutes hugo-minutes
+          git commit -m "Automated minutes update" || echo "No changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ No build process required for the main site - all files are production-ready.
 The Hugo minutes system deploys automatically via GitHub Actions:
 - **Trigger**: Daily at 6 AM UTC, or manual workflow dispatch
 - **Source**: Latest content from `ccowmu/minutes` repository
-- **Output**: Static files generated in `hugo-minutes/public/`
+- **Output**: Static files generated in `minutes/`
 - **Integration**: Seamlessly integrated with main site at `/minutes`
 
 To manually deploy minutes:
-1. Run `hugo --minify` in `hugo-minutes/` directory
-2. Copy `public/` contents to your web server's `/minutes` directory
+1. Run `hugo --minify -s hugo-minutes -d ../minutes`
+2. Copy the generated `minutes/` directory to your web server
 
 ## 📝 Content Management
 

--- a/hugo-minutes/README.md
+++ b/hugo-minutes/README.md
@@ -1,0 +1,3 @@
+This directory contains the Hugo configuration used to build the meeting minutes
+section. Markdown minutes are pulled from the `ccowmu/minutes` repository and
+converted into static pages via GitHub Actions.

--- a/hugo-minutes/archetypes/default.md
+++ b/hugo-minutes/archetypes/default.md
@@ -1,0 +1,5 @@
+---
+title: ""
+date: {{ .Date }}
+draft: true
+---

--- a/hugo-minutes/hugo.toml
+++ b/hugo-minutes/hugo.toml
@@ -1,0 +1,11 @@
+baseURL = "/minutes/"
+relativeURLs = true
+canonifyURLs = false
+languageCode = "en-us"
+title = "CCaWMU Meeting Minutes"
+theme = "minutes-theme"
+paginate = 20
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true

--- a/hugo-minutes/themes/minutes-theme/layouts/_default/baseof.html
+++ b/hugo-minutes/themes/minutes-theme/layouts/_default/baseof.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+  <link rel="stylesheet" href="{{ "css/style.css" | relURL }}">
+</head>
+<body>
+  {{ partial "header.html" . }}
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+  {{ partial "footer.html" . }}
+  <script src="{{ "js/main.js" | relURL }}"></script>
+</body>
+</html>

--- a/hugo-minutes/themes/minutes-theme/layouts/_default/list.html
+++ b/hugo-minutes/themes/minutes-theme/layouts/_default/list.html
@@ -1,0 +1,9 @@
+{{ define "title" }}Meeting Minutes - {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<h1>Meeting Minutes</h1>
+<ul>
+  {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> - {{ .Date.Format "Jan 2, 2006" }}</li>
+  {{ end }}
+</ul>
+{{ end }}

--- a/hugo-minutes/themes/minutes-theme/layouts/_default/single.html
+++ b/hugo-minutes/themes/minutes-theme/layouts/_default/single.html
@@ -1,0 +1,8 @@
+{{ define "title" }}{{ .Title }} - {{ .Site.Title }}{{ end }}
+{{ define "main" }}
+<article>
+  <h1>{{ .Title }}</h1>
+  <time>{{ .Date.Format "January 2, 2006" }}</time>
+  {{ .Content }}
+</article>
+{{ end }}

--- a/hugo-minutes/themes/minutes-theme/layouts/partials/footer.html
+++ b/hugo-minutes/themes/minutes-theme/layouts/partials/footer.html
@@ -1,0 +1,79 @@
+<footer class="site-footer">
+    <div class="footer-scanlines"></div>
+    <div class="container">
+        <div class="footer-content">
+            <!-- Contact Info -->
+            <div class="footer-section footer-buttons-section">
+                <h3>Connect With Us</h3>
+                <div class="footer-buttons">
+                    <a href="mailto:rso_cclub@wmich.edu" class="footer-button">
+                        <span class="button-icon"><img src="images/mail.png" alt="Email" class="footer-icon"></span>
+                        <span>Email Us</span>
+                    </a>
+                    <a href="tel:+16165041337" class="footer-button">
+                        <span class="button-icon"><img src="images/telephone.png" alt="Phone" class="footer-icon"></span>
+                        <span>Call Us</span>
+                    </a>
+                    <a href="https://github.com/ccowmu" class="footer-button" target="_blank" rel="noopener">
+                        <span class="button-icon"><img src="images/github-mark-white.png" alt="GitHub" class="footer-icon"></span>
+                        <span>GitHub</span>
+                    </a>
+                    <a href="https://www.flickr.com/photos/ccawmu/" class="footer-button" target="_blank" rel="noopener">
+                        <span class="button-icon"><img src="images/flickr.png" alt="Flickr" class="footer-icon"></span>
+                        <span>Flickr</span>
+                    </a>
+                    <a href="https://linktr.ee/ccawmu" class="footer-button" target="_blank" rel="noopener">
+                        <span class="button-icon"><img src="images/linktree.png" alt="Linktree" class="footer-icon"></span>
+                        <span>Linktree</span>
+                    </a>
+                    <a href="chat.html" class="footer-button">
+                        <span class="button-icon"><img src="images/logo-mark-primary.svg" alt="Matrix Chat" class="footer-icon"></span>
+                        <span>Matrix Chat</span>
+                    </a>
+                </div>
+            </div>
+
+            <!-- Quick Links -->
+            <div class="footer-section footer-buttons-section">
+                <h3>Quick Links</h3>
+                <div class="footer-buttons">
+                    <a href="minutes.html" class="footer-button">
+                        <span class="button-icon">📋</span>
+                        <span>Meeting Minutes</span>
+                    </a>
+                    <a href="events.html" class="footer-button">
+                        <span class="button-icon">📅</span>
+                        <span>Upcoming Events</span>
+                    </a>
+                    <a href="wiki.html" class="footer-button">
+                        <span class="button-icon">📚</span>
+                        <span>Club Wiki</span>
+                    </a>
+                    <a href="rss.xml" class="footer-button" target="_blank" rel="noopener">
+                        <span class="button-icon">📡</span>
+                        <span>RSS Feed</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Footer Bottom -->
+        <div class="footer-bottom">
+            <div class="footer-text">
+                <p>&copy; 2025 Computer Club at Western Michigan University</p>
+                <p class="footer-motto">Built with ❤️, caffeine, and way too many late nights</p>
+            </div>
+            <div class="footer-ascii">
+                <pre class="ascii-art">
+ ██████╗ ██████╗ █████╗ ██╗    ██╗███╗   ███╗██╗   ██╗
+██╔════╝██╔════╝██╔══██╗██║    ██║████╗ ████║██║   ██║
+██║     ██║     ███████║██║ █╗ ██║██╔████╔██║██║   ██║
+██║     ██║     ██╔══██║██║███╗██║██║╚██╔╝██║██║   ██║
+╚██████╗╚██████╗██║  ██║╚███╔███╔╝██║ ╚═╝ ██║╚██████╔╝
+ ╚═════╝ ╚═════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚═╝     ╚═╝ ╚═════╝ 
+                                                                
+                </pre>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/hugo-minutes/themes/minutes-theme/layouts/partials/header.html
+++ b/hugo-minutes/themes/minutes-theme/layouts/partials/header.html
@@ -1,0 +1,50 @@
+<header class="site-header">
+    <nav class="navbar">
+        <div class="nav-container">
+            <!-- Logo/Brand -->
+            <div class="nav-brand">
+                <a href="/ccowmu.org/index.html" class="brand-link">
+                    <span class="brand-text">CCaWMU</span>
+                </a>
+            </div>
+
+            <!-- Navigation Links -->
+            <ul class="nav-menu" id="nav-menu">
+                <li class="nav-item">
+                    <a href="/ccowmu.org/index.html" class="nav-link">Home</a>
+                </li>
+                <li class="nav-item">
+                    <a href="/ccowmu.org/minutes.html" class="nav-link">Minutes</a>
+                </li>
+                <li class="nav-item">
+                    <a href="/ccowmu.org/chat.html" class="nav-link">Chat</a>
+                </li>
+                <li class="nav-item">
+                    <a href="https://experiencewmu.wmich.edu/organization/computer-club-at-wmu/events" class="nav-link">Events</a>
+                </li>
+                <li class="nav-item">
+                    <a href="https://cclub.cs.wmich.edu/wiki/Main_Page" class="nav-link">Wiki</a>
+                </li>
+            </ul>
+
+            <!-- Controls -->
+            <div class="nav-controls">
+                <!-- Theme Toggle -->
+                <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
+                    <span class="theme-icon light">☀</span>
+                    <span class="theme-icon dark">☾</span>
+                </button>
+
+                <!-- Join Button -->
+                <a href="/ccowmu.org/join.html" class="nav-join-btn">Join</a>
+            </div>
+
+            <!-- Mobile Menu Toggle -->
+            <div class="nav-toggle" id="nav-toggle">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </div>
+        </div>
+    </nav>
+</header>


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to pull markdown and build minutes
- include minimal Hugo configuration and theme
- document new build output path

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68733b0ae5348332bcf9aa3b09d42ce1